### PR TITLE
Remove subscription on null data

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1441,6 +1441,12 @@ _queryExchangeState(pair)
             {
                 return;
             }
+            // probably, invalid trading pair
+            if (data === null) {
+                delete self._subscriptions.markets.pairs[pair];
+                return;
+            }
+
             self._subscriptions.markets.pairs[pair].lastCseq = data.N;
 
             // build events

--- a/lib/client.js
+++ b/lib/client.js
@@ -1441,8 +1441,18 @@ _queryExchangeState(pair)
             {
                 return;
             }
-            // probably, invalid trading pair
-            if (data === null) {
+            // probably an invalid trading pair
+            if (null === data) 
+            {
+                if (debug.enabled)
+                {
+                    debug("QueryExchangeState returned null for pair '%s' (probably an invalid pair)", pair);
+                }
+                if (null !== self._logger)
+                {
+                    self._logger.warn("QueryExchangeState returned null for pair '%s' (probably an invalid pair)", pair);
+                }
+                // remove subscription
                 delete self._subscriptions.markets.pairs[pair];
                 return;
             }


### PR DESCRIPTION
It seems that Bittrex sends null when subscribing for invalid trading pair. Right now it happens for BTC-BCC and USDT-BCC.

I've added a escape from data processing code when it happens