### PR TITLE
Including missing orderbook update type ADD

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1684,6 +1684,10 @@ _processUpdateExchangeState(d)
                     {
                         action = 'remove';
                     }
+                    if (0 == entry.TY)
+                    {
+                        action = 'add';
+                    }
                     return {
                         action:action,
                         rate:parseFloat(entry.R),
@@ -1695,6 +1699,10 @@ _processUpdateExchangeState(d)
                     if (1 == entry.TY)
                     {
                         action = 'remove';
+                    }
+                    if (0 == entry.TY)
+                    {
+                        action = 'add';
                     }
                     return {
                         action:action,


### PR DESCRIPTION
Hello,

According to bittrex [documentation](https://github.com/Bittrex/bittrex.github.io#market-delta---ue), there are 3 types of orderbook updates: ADD, REMOVE and UPDATE but [implementation in this library](https://github.com/aloysius-pgast/bittrex-signalr-client/blob/master/lib/client.js#L1683) only take REMOVE or UPDATE into account. 

This pull request include the missing type (ADD)